### PR TITLE
Add react_remote_js_build variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -508,6 +508,7 @@ grp_react_git_key: "{{ grp_django_git_key }}"
 grp_react_git_key_ssh_file: "{{ grp_django_git_key_ssh_file }}"
 grp_react_git_key_filename: "{{ grp_django_git_key_filename }}"
 grp_react_remove_git_key: True
+grp_react_remote_js_build: yes
 grp_react_app_settings:
   REACT_APP_WEBSITE_NAME: "{{ grp_django_system_user }}"
   REACT_APP_ENDPOINT: "https://grp.stage.ona.io/api/v1"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -102,6 +102,7 @@ dependencies:
       react_git_key_filename: "{{ grp_react_git_key_filename }}"
       react_remove_git_key: "{{ grp_react_remove_git_key }}"
       react_app_settings: "{{ grp_react_app_settings }}"
+      react_remote_js_build: "{{ grp_react_remote_js_build }}"
     tags:
       - react
       - staticfiles


### PR DESCRIPTION
To support local JS builds during deployment. Compiling
on target servers seems to take way too long as compared
to the less than 5 minutes locally.