### PR TITLE
Lock django-debug-toolbar to version 2.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -151,7 +151,7 @@ grp_django_pip_packages:
   - celery
   - uwsgi
   - redis>3
-  - django-debug-toolbar
+  - django-debug-toolbar==2.2
 grp_django_celeryd_nodes: "default-node"
 grp_django_celeryd_opts: "--time-limit=300 --concurrency=8"
 grp_django_app_settings:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -48,7 +48,7 @@
           - celery
           - uwsgi
           - redis>3
-          - django-debug-toolbar
+          - django-debug-toolbar==2.2
         grp_django_celeryd_nodes: "default-node"
         grp_django_celeryd_opts: "--time-limit=300 --concurrency=8"
         grp_django_app_settings:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -63,7 +63,7 @@
     - celery
     - uwsgi
     - redis>3
-    - django-debug-toolbar
+    - django-debug-toolbar==2.2
     grp_django_celeryd_nodes: "default-node"
     grp_django_celeryd_opts: "--time-limit=300 --concurrency=8"
     grp_django_app_settings:


### PR DESCRIPTION
Fixes #12 